### PR TITLE
vueのrouterが動かないバグ修正

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module gin_mod
 
-go 1.15
+// +heroku goVersion go1.12
+go 1.12
 
 replace local.packages/server => ./server
 

--- a/server/go.mod
+++ b/server/go.mod
@@ -1,6 +1,6 @@
 module server
 
-go 1.15
+go 1.12
 
 require (
 	github.com/gin-contrib/cors v1.3.1

--- a/server/server.go
+++ b/server/server.go
@@ -35,6 +35,9 @@ func Server() {
 			portfolioEngine.POST("", postPortfolioHandler)
 		}
 	}
+	engine.NoRoute(func(c *gin.Context) {
+		c.File("./static/index.html")
+	})
 	port := os.Getenv("PORT")
 
 	if port == "" {


### PR DESCRIPTION
routerが、goのrouter依存になっており、vueで設定したrouterが正しく動かないバグがあったため対応