### PR TITLE
herokuで使用するgoバージョンを変更

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module gin_mod
 
-// +heroku goVersion go1.12
-go 1.12
+// +heroku goVersion go1.15
+go 1.15
 
 replace local.packages/server => ./server
 

--- a/server/go.mod
+++ b/server/go.mod
@@ -1,6 +1,6 @@
 module server
 
-go 1.12
+go 1.15
 
 require (
 	github.com/gin-contrib/cors v1.3.1


### PR DESCRIPTION
 herokuのデフォルトのgo versionが12であるため最新のライブラリが利用できなかった。
明示的にバージョンを指定するように修正した